### PR TITLE
Add Sphinx Limit to options

### DIFF
--- a/src/Model/Behavior/SphinxBehavior.php
+++ b/src/Model/Behavior/SphinxBehavior.php
@@ -29,7 +29,8 @@ class SphinxBehavior extends Behavior
     public function search($options) {
         $sphinx = SphinxQL::create($this->conn)->select('id')
             ->from($options['index'])
-            ->match((empty($options['match_fields']) ? "*" : $options['match_fields']), $options['term']);
+            ->match((empty($options['match_fields']) ? "*" : $options['match_fields']), $options['term'])
+            ->limit((empty($options['limit'])) ? 1000 : $options['limit']);
 
         $result = $sphinx->execute();
 


### PR DESCRIPTION
By default sphinx has a limit of 20 results, this extends the options by adding in a limit parameter with a default of 1000.
