### PR TITLE
Allow custom config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+vendor/
+.idea/
+composer.lock
+

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ It currently has one function and that is to query the provided index and return
 * Add ````Plugin::load('Sphinx');```` to your bootstrap.php
 * Attach the behaviour to a table you wish to search on 
 (There must be an index that is generated from this model - the behaviour works by pulling the ID's from Sphinx and then fetching them from the DB (See TODO's for improving this)
+* Behavior config options:
+  * `'connection' => ['host' => 'hostname', 'port' => 'port']`
+  * `'defaultIndex' => 'index_name`
 
 ```php
 <?php 
@@ -51,7 +54,6 @@ class PostsTable extends Table
         $this->addBehavior('Sphinx.Sphinx');
     }
 }
-?>
 ```
 
 * Perform a search through the behaviour directly (This will return a query object), it takes an array of the following parameters:
@@ -104,7 +106,6 @@ public function testBehaviour()
 }
 ```
 ###TODO
-* Allow for custom configuration to be passed in
 * Give option for all data to be pulled from Sphinxsearch directly rather than then querying DB
 * Hook into afterSave and have the Sphinx index updated (this isn't a priority for me as my indexes don't need to be live but please submit a pull request if you want to add this)
 * Work out how to test this easily on Travis (again - help appreciated)

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ It currently has one function and that is to query the provided index and return
 * Attach the behaviour to a table you wish to search on 
 (There must be an index that is generated from this model - the behaviour works by pulling the ID's from Sphinx and then fetching them from the DB (See TODO's for improving this)
 * Behavior config options:
-  * `'connection' => ['host' => 'hostname', 'port' => 'port']`
-  * `'defaultIndex' => 'index_name`
+  * `'connection' => ['host' => 'hostname', 'port' => 'port']` (default hostname is 'localhost' and default port is 9306)
+  * `'defaultIndex' => 'index_name'`
 
 ```php
 <?php 

--- a/src/Model/Behavior/SphinxBehavior.php
+++ b/src/Model/Behavior/SphinxBehavior.php
@@ -2,43 +2,55 @@
 namespace Sphinx\Model\Behavior;
 
 use Cake\ORM\Behavior;
-use Cake\ORM\Entity;
-use Cake\ORM\Query;
-use Cake\ORM\Table;
 use Cake\Utility\Hash;
 use Foolz\SphinxQL\Drivers\Mysqli\Connection;
 use Foolz\SphinxQL\SphinxQL;
 
-
+/**
+ * Class SphinxBehavior
+ */
 class SphinxBehavior extends Behavior
 {
+    /** @var \Foolz\SphinxQL\Drivers\Mysqli\Connection */
     public $conn;
-    public $table;
 
-    public function __construct(Table $table, array $config = ['host' => 'localhost', 'port' => 9306]) {
+    /** @var array */
+    protected $_defaultConfig = [
+        'connection' => [
+            'host' => 'localhost',
+            'port' => '9306',
+        ],
+    ];
+
+    /**
+     * @param array $config
+     */
+    public function initialize(array $config)
+    {
         $this->conn = new Connection();
-        $this->table = $table;
-        $this->conn->setParams(['host' => $config['host'], 'port' => $config['port']]);
+        $this->conn->setParams([
+            'host' => $this->config('connection')['host'],
+            'port' => $this->config('connection')['port'],
+        ]);
     }
-
 
     /**
      * @param $options (match_fields, paginate)
-     * @return Query
+     * @return \Cake\ORM\Query
      */
-    public function search($options) {
+    public function search(array $options)
+    {
         $sphinx = SphinxQL::create($this->conn)->select('id')
             ->from($options['index'])
             ->match((empty($options['match_fields']) ? "*" : $options['match_fields']), $options['term'])
             ->limit((empty($options['limit'])) ? 1000 : $options['limit']);
 
-        $result = $sphinx->execute();
+        $result = $sphinx->execute()->fetchAllAssoc();
 
         if (!empty($result)) {
 
             $ids = Hash::extract($result, '{n}.id');
-            
-            $query = $this->table->find();
+            $query = $this->_table->find();
             
             if (!empty($options['paginate']['fields'])) {
                 $query->select($options['paginate']['fields']);
@@ -48,7 +60,7 @@ class SphinxBehavior extends Behavior
                 $query->contain($options['paginate']['contain']);
             }
             
-            $query->where([$this->table->alias() . '.id IN' => $ids]);
+            $query->where([$this->_table->alias() . '.' . $this->_table->primaryKey() . ' IN' => $ids]);
 
             return $query;
         }

--- a/src/Model/Behavior/SphinxBehavior.php
+++ b/src/Model/Behavior/SphinxBehavior.php
@@ -6,8 +6,8 @@ use Cake\ORM\Entity;
 use Cake\ORM\Query;
 use Cake\ORM\Table;
 use Cake\Utility\Hash;
+use Foolz\SphinxQL\Drivers\Mysqli\Connection;
 use Foolz\SphinxQL\SphinxQL;
-use Foolz\SphinxQL\Connection;
 
 
 class SphinxBehavior extends Behavior

--- a/src/Model/Behavior/SphinxBehavior.php
+++ b/src/Model/Behavior/SphinxBehavior.php
@@ -20,6 +20,7 @@ class SphinxBehavior extends Behavior
             'host' => 'localhost',
             'port' => '9306',
         ],
+        'defaultIndex' => '',
     ];
 
     /**
@@ -40,15 +41,15 @@ class SphinxBehavior extends Behavior
      */
     public function search(array $options)
     {
+        $index = isset($options['index']) ? $options['index'] : $this->config('defaultIndex');
         $sphinx = SphinxQL::create($this->conn)->select('id')
-            ->from($options['index'])
+            ->from($index)
             ->match((empty($options['match_fields']) ? "*" : $options['match_fields']), $options['term'])
             ->limit((empty($options['limit'])) ? 1000 : $options['limit']);
 
         $result = $sphinx->execute()->fetchAllAssoc();
 
         if (!empty($result)) {
-
             $ids = Hash::extract($result, '{n}.id');
             $query = $this->_table->find();
             

--- a/src/Model/Behavior/SphinxBehavior.php
+++ b/src/Model/Behavior/SphinxBehavior.php
@@ -25,6 +25,7 @@ class SphinxBehavior extends Behavior
 
     /**
      * @param array $config
+     * @return void
      */
     public function initialize(array $config)
     {
@@ -37,7 +38,7 @@ class SphinxBehavior extends Behavior
 
     /**
      * @param $options (match_fields, paginate)
-     * @return \Cake\ORM\Query
+     * @return \Cake\ORM\Query|bool
      */
     public function search(array $options)
     {


### PR DESCRIPTION
This PR allows certain custom config to be passed into the behaviour, specifically connection details and a default index to use for the table that the behaviour is attached to.  

Usage example:

``` php
    public function initialize(array $config)
    {
        parent::initialize($config);
        ...
        $this->addBehavior('Sphinx.Sphinx', [
            'connection' => [
                'host' => '192.168.99.100',
                'port' => '9306',
            ],
            'defaultIndex' => 'test1',
        ]);
    }
```

It also replaces the deprecated `Foolz\SphinxQL\Connection` class with `Foolz\SphinxQL\Drivers\Mysqli\Connection`.
